### PR TITLE
sync pyproject version and release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   'numpy >= 1.24.3',
   'pymatgen >= 2023.5.10',  
 ]
-version = "0.1"
+version = "0.1.1"
 authors = [
   { name="Patrick Melix", email="patrick.melix@uni-leipzig.de" },
 ]


### PR DESCRIPTION
There's a version mismatch between the tags and the pyproject.toml