### PR TITLE
fix: resolve bugs across 10 files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ vasp2traj = "tools4vasp.vasp2traj:main"
 vaspcheck = "tools4vasp.vaspcheck:main"
 vaspGetEF = "tools4vasp.vaspGetEF:main"
 viewMode = "tools4vasp.viewMode:main"
-visualize-maagnetization = "tools4vasp.visualize_magnetization:main"
+visualize-magnetization = "tools4vasp.visualize_magnetization:main"
 
 
 [tool.setuptools]

--- a/src/tools4vasp/chgcar2cube.py
+++ b/src/tools4vasp/chgcar2cube.py
@@ -58,30 +58,30 @@ def chgcar2cube(inFiles, outFiles, verbose=True, return_integrals=False, return_
                     spin_integral /= n_data
                 print("Integral of diff data is {}".format(spin_integral))
 
-            origin = np.zeros(3)
-            atoms = AseAtomsAdaptor.get_atoms(full_chgcar.structure)
+        origin = np.zeros(3)
+        atoms = AseAtomsAdaptor.get_atoms(full_chgcar.structure)
 
-            #Contrary to VASP Wiki, the CHGCAR is not rho*V, but rho*n_data.
-            #So in order to have the integral over space = nelectrons, we need to divide by n_data.
-            #Since this would result in super small numbers, we can transform to rho*V
-            factor = n_data
-            if mult_volume:
-                factor /= atoms.get_volume()
-            full_chgcar.data['total'] /= factor
-            if spinpol:
-                full_chgcar.data['diff'] /= factor
-            #write cube
-            filename = "{}.cube".format(outFiles[iFile])
+        #Contrary to VASP Wiki, the CHGCAR is not rho*V, but rho*n_data.
+        #So in order to have the integral over space = nelectrons, we need to divide by n_data.
+        #Since this would result in super small numbers, we can transform to rho*V
+        factor = n_data
+        if mult_volume:
+            factor /= atoms.get_volume()
+        full_chgcar.data['total'] /= factor
+        if spinpol:
+            full_chgcar.data['diff'] /= factor
+        #write cube
+        filename = "{}.cube".format(outFiles[iFile])
+        if verbose:
+            print("Writing {}".format(filename))
+        with open(filename, 'w') as f:
+            write_cube(f, atoms, data=full_chgcar.data['total'], origin=origin)
+        if spinpol:
+            filename = "{}_mag.cube".format(outFiles[iFile])
             if verbose:
                 print("Writing {}".format(filename))
             with open(filename, 'w') as f:
-                write_cube(f, atoms, data=full_chgcar.data['total'], origin=origin)
-            if spinpol:
-                filename = "{}_mag.cube".format(outFiles[iFile])
-                if verbose:
-                    print("Writing {}".format(filename))
-                with open(filename, 'w') as f:
-                    write_cube(f, atoms, data=full_chgcar.data['diff'], origin=origin)
+                write_cube(f, atoms, data=full_chgcar.data['diff'], origin=origin)
                 
     if return_integrals:
         if len(integrals) == 1:

--- a/src/tools4vasp/elf2cube.py
+++ b/src/tools4vasp/elf2cube.py
@@ -12,7 +12,7 @@ import numpy as np
 import os
 
 
-def main(inFiles, outFiles, verbose=True, return_integrals=False, return_spin_integrals=False):
+def elf2cube(inFiles, outFiles, verbose=True, return_integrals=False, return_spin_integrals=False):
     assert len(inFiles) == len(outFiles), "Number of input and output files must be equal!"
     integrals = []
     spin_integrals = []
@@ -30,7 +30,7 @@ def main(inFiles, outFiles, verbose=True, return_integrals=False, return_spin_in
             print("Reading {}".format(inFile))
         full_elfcar = Elfcar.from_file(inFile)
         spinpol = 'diff' in full_elfcar.data.keys()
-        #pymatgen: “total” key refers to Spin.up, and “diff” refers to Spin.down.
+        #pymatgen: "total" key refers to Spin.up, and "diff" refers to Spin.down.
         if return_spin_integrals and not spinpol:
             raise ValueError("File {} is not spinpolarized!".format(inFile))
         shape = full_elfcar.data['total'].shape
@@ -60,32 +60,32 @@ def main(inFiles, outFiles, verbose=True, return_integrals=False, return_spin_in
                     spin_integral = (np.sum(np.abs(full_elfcar.data['total'])), np.sum(np.abs(full_elfcar.data['diff'])))
                 print("Integral of spin data is up: {}, down: {}".format(*spin_integral))
 
-            origin = np.zeros(3)
-            atoms = AseAtomsAdaptor.get_atoms(full_elfcar.structure)
+        origin = np.zeros(3)
+        atoms = AseAtomsAdaptor.get_atoms(full_elfcar.structure)
 
-            # write cubes
-            if spinpol:
-                filename = "{}_up.cube".format(outFiles[iFile])
-                if verbose:
-                    print("Writing {}".format(filename))
-                with open(filename, 'w') as f:
-                    write_cube(f, atoms, data=full_elfcar.data['total'], origin=origin)
-                filename = "{}_down.cube".format(outFiles[iFile])
-                if verbose:
-                    print("Writing {}".format(filename))
-                with open(filename, 'w') as f:
-                    write_cube(f, atoms, data=full_elfcar.data['diff'], origin=origin)
-                filename = "{}_diff.cube".format(outFiles[iFile])
-                if verbose:
-                    print("Writing {}".format(filename))
-                with open(filename, 'w') as f:
-                    write_cube(f, atoms, data=full_elfcar.data['total']-full_elfcar.data['diff'], origin=origin)
-            else:
-                filename = "{}.cube".format(outFiles[iFile])
-                if verbose:
-                    print("Writing {}".format(filename))
-                with open(filename, 'w') as f:
-                    write_cube(f, atoms, data=full_data, origin=origin)
+        # write cubes
+        if spinpol:
+            filename = "{}_up.cube".format(outFiles[iFile])
+            if verbose:
+                print("Writing {}".format(filename))
+            with open(filename, 'w') as f:
+                write_cube(f, atoms, data=full_elfcar.data['total'], origin=origin)
+            filename = "{}_down.cube".format(outFiles[iFile])
+            if verbose:
+                print("Writing {}".format(filename))
+            with open(filename, 'w') as f:
+                write_cube(f, atoms, data=full_elfcar.data['diff'], origin=origin)
+            filename = "{}_diff.cube".format(outFiles[iFile])
+            if verbose:
+                print("Writing {}".format(filename))
+            with open(filename, 'w') as f:
+                write_cube(f, atoms, data=full_elfcar.data['total']-full_elfcar.data['diff'], origin=origin)
+        else:
+            filename = "{}.cube".format(outFiles[iFile])
+            if verbose:
+                print("Writing {}".format(filename))
+            with open(filename, 'w') as f:
+                write_cube(f, atoms, data=full_data, origin=origin)
 
     if return_integrals:
         if len(integrals) == 1:
@@ -102,11 +102,15 @@ def main(inFiles, outFiles, verbose=True, return_integrals=False, return_spin_in
         return
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     parser = argparse.ArgumentParser(description='Convert one or many ELFCAR files to cube format.')
     parser.add_argument('input', type=str, nargs='+', help='Input Files')
     parser.add_argument('-output', type=str, nargs='+', help='Output File Names (no extension)')
     parser.add_argument('-v', help='Verbose', action='store_true')
     args = parser.parse_args()
-    main(args.input, args.output, verbose=args.v)
+    elf2cube(args.input, args.output, verbose=args.v)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools4vasp/freq2mode.py
+++ b/src/tools4vasp/freq2mode.py
@@ -55,8 +55,8 @@ def write_modecar(frequency, filename):
                 line += "   "
             line += "{:.10E}".format(freq)
         filestring += line + "\n"
-        with open(filename, "w") as file:
-            file.write(filestring)
+    with open(filename, "w") as file:
+        file.write(filestring)
 
 
 def read_frequency_from_outcar(outcar, freq_line, atoms):

--- a/src/tools4vasp/kgrid2kspacing.py
+++ b/src/tools4vasp/kgrid2kspacing.py
@@ -26,9 +26,13 @@ def get_kspacing():
     print("The corresponding KSPACING for KGRID {} {} {} is {}Å^-1, {}Å^-1, {}Å^-1".format(*kgrid, *[ round(k, 3) for k in kspacing ]))
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     parser = argparse.ArgumentParser(
         description='Get a KSPACING from current POSCAR and KPOINTS')
-    args = parser.parse_args()
+    parser.parse_args()
     get_kspacing()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools4vasp/kspacing2kgrid.py
+++ b/src/tools4vasp/kspacing2kgrid.py
@@ -18,10 +18,14 @@ def get_kgrid(kspacing):
     print("The corresponding KGRID for KSPACING {}Å^-1 is: {} {} {}".format(kspacing, *kgrid))
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     parser = argparse.ArgumentParser(
         description='Get a KGrid from current POSCAR and a KSPACING value')
     parser.add_argument('kspacing', type=float, help='KSPACING value')
     args = parser.parse_args()
     get_kgrid(args.kspacing)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools4vasp/neb2movie.py
+++ b/src/tools4vasp/neb2movie.py
@@ -8,7 +8,7 @@ from ase import io
 import os
 import glob
 
-def main(outFile='movie.xyz', workdir='.', wrap='False', use=None):
+def main(outFile='movie.xyz', workdir='.', wrap=False, use=None):
     """
         use: None -> Auto use CONTCAR if available, otherwise POSCAR
              CONTCAR or POSCAR

--- a/src/tools4vasp/plotIRC.py
+++ b/src/tools4vasp/plotIRC.py
@@ -61,7 +61,7 @@ def read_irc(directory):
     return init_structure, steps, energies
 
 
-def generate_plot(irc_e, irc_p, ts):
+def generate_plot(irc_e, irc_p, ts, offset=None):
     # check if a transition state was supplied. otherwise use the first image of the product irc as the image
     ts_exists = True
     if ts is None:
@@ -96,15 +96,15 @@ def generate_plot(irc_e, irc_p, ts):
             irc_e[1][i] = (irc_e[1][i] * (-1)) - reactant_offset
     # Generate basic plot data
     # Offset energy
-    if args.offset is None:
-        offset = 0 - ts[1]
+    if offset is None:
+        energy_offset = 0 - ts[1]
     else:
-        offset = args.offset - ts[1]
+        energy_offset = offset - ts[1]
     for i in range(len(irc_e[2])):
-        irc_e[2][i] = irc_e[2][i] + offset
+        irc_e[2][i] = irc_e[2][i] + energy_offset
     for i in range(len(irc_p[2])):
-        irc_p[2][i] = irc_p[2][i] + offset
-    ts = (ts[0], ts[1] + offset)
+        irc_p[2][i] = irc_p[2][i] + energy_offset
+    ts = (ts[0], ts[1] + energy_offset)
     # Generate additional plot data
     if ts_exists:
         s_plot_x = [irc_e[1][0], 0, irc_p[1][0]]
@@ -132,7 +132,7 @@ def plot_irc(irc_data, silent=False):
         plt.show()
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         prog='plotIRC',
         description='Tool that creates a plot of VASP IRC calculations in both direction and is compatible with shifts in the starting structure.',
@@ -154,8 +154,12 @@ if __name__ == "__main__":
     irc_e = read_irc(args.reactant_dir)
     irc_p = read_irc(args.product_dir)
     if args.transition_state == "none":
-        plot_data = generate_plot(irc_e, irc_p, None)
+        plot_data = generate_plot(irc_e, irc_p, None, offset=args.offset)
     else:
         ts = read_sp(args.transition_state, args.allow_freq)
-        plot_data = generate_plot(irc_e, irc_p, ts)
+        plot_data = generate_plot(irc_e, irc_p, ts, offset=args.offset)
     plot_irc(plot_data, args.silent)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools4vasp/plotNEB.py
+++ b/src/tools4vasp/plotNEB.py
@@ -21,6 +21,8 @@ def plot(reactionCoord, reactionCoordImageAxis, energies, energySpline, forces, 
         parts = unit.split("/")
         assert len(parts) == 2, "Only one division allowed for unit conversion."
         unit_label = r"$\mathrm{" + parts[0] + "}" + r"\,\mathrm{" + parts[1] + r"}^{-1}$"
+    else:
+        unit_label = r"$\mathrm{" + unit + r"}$"
     msbig = 9
     ax = plt.figure().gca()
     ax.xaxis.set_major_locator(MaxNLocator(integer=True))
@@ -37,20 +39,21 @@ def plot(reactionCoord, reactionCoordImageAxis, energies, energySpline, forces, 
     delta = dScale*maxX
     yRange = max(energySpline) - min(energySpline)
     for i,x in enumerate(reactionCoordImageAxis):
-        tangentX = [x-delta, x+delta]
-        tangentY = [energies[i]+(delta*forces[i]),energies[i]-(delta*forces[i])] #invert sign of forces from neb output
+        cur_delta = delta
+        tangentX = [x-cur_delta, x+cur_delta]
+        tangentY = [energies[i]+(cur_delta*forces[i]),energies[i]-(cur_delta*forces[i])] #invert sign of forces from neb output
         if i == 0:
             label = 'NEB Force'
         else:
             label = None
         # limit y range of tangent
         tangentYRange = max(tangentY) - min(tangentY)
-        factor = delta * 0.1
+        factor = cur_delta * 0.1
         n = 1
         while tangentYRange > 0.1 * yRange:
-            delta -= factor
-            tangentX = [x-delta, x+delta]
-            tangentY = [energies[i]+(delta*forces[i]),energies[i]-(delta*forces[i])] #invert sign of forces from neb output
+            cur_delta -= factor
+            tangentX = [x-cur_delta, x+cur_delta]
+            tangentY = [energies[i]+(cur_delta*forces[i]),energies[i]-(cur_delta*forces[i])] #invert sign of forces from neb output
             tangentYRange = max(tangentY) - min(tangentY)
             n += 1
             if n >= 11:
@@ -147,7 +150,6 @@ def main(filename='NEB.png', presentation=False,
 
 
 if __name__ == "__main__":
-    exec(open("/home/patrickm/git/Python4ChemistryTools/mpl-settings.py").read())
     parser = argparse.ArgumentParser(description='Plot VASP+TST NEB results')
     parser.add_argument('--file', help='Plot Filename', default='NEB.png')
     parser.add_argument('--presentation', help='Presentation Mode (i.e. thicker lines)', action='store_true')

--- a/src/tools4vasp/vaspGetEF.py
+++ b/src/tools4vasp/vaspGetEF.py
@@ -63,7 +63,7 @@ def read_xml(path, verbose=False, write_fe=False) -> Tuple[List[float]]:
         fe.close()
     return forces, energies
 
-def get_all_xmls(path, vervose=False) -> List[str]:
+def get_all_xmls(path, verbose=False) -> List[str]:
     """Get all xml files in the path and numerical subdirectories.
 
     Input Parameters
@@ -114,7 +114,7 @@ def process_all_xmls(path, verbose=False, write_json=False) -> Dict[str, List[fl
                 print("Adding {}".format(folder))
         else:
             print("Generating fe.dat in {}".format(folder))
-            f, e = read_xml(f, verbose=verbose, write_fe=True)
+            read_xml(f, verbose=verbose, write_fe=True)
             assert os.path.isfile(os.path.join(folder,'fe.dat')), "Problem generating fe.dat in {:}".format(folder)
         to_add = np.loadtxt(os.path.join(folder,'fe.dat'))
         # check if only one entry


### PR DESCRIPTION
- chgcar2cube: cube files were never written when verbose=False (wrong indentation placed all conversion/write logic inside `if verbose:`)
- elf2cube: same verbose-indentation bug; also rename core function to elf2cube() and add proper main() for the console-script entry point
- plotNEB: remove hardcoded developer path that crashed for all users; fix NameError when unit has no "/" (unit_label was never set in else branch); fix delta being mutated across loop iterations (use per-iteration copy)
- plotIRC: add main() function required by the console-script entry point; fix generate_plot() accessing global `args` (fails when used as a module) by passing offset as an explicit parameter
- kgrid2kspacing, kspacing2kgrid: add main() functions required by the console-script entry points
- neb2movie: wrap default was string 'False' (always truthy) instead of boolean False, causing unconditional wrapping
- freq2mode: write_modecar() was writing the file inside the outer loop, rewriting it partially on every iteration; moved write outside the loop
- vaspGetEF: fix 'vervose' typo in get_all_xmls parameter; fix variable shadowing where loop variable `f` was overwritten by return value of read_xml()
- pyproject.toml: fix 'visualize-maagnetization' typo in console-script name