### PR TITLE
deps: add scipy to project dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ that OIDC requires.
 | `matplotlib` | All plotting tools |
 | `natsort` | Natural-sort for run-folder discovery |
 | `numpy` | Numerical operations |
+| `scipy` | Plane fitting for surface/molecule splitting and XY-rotation |
 
 Optional (not installed in CI):
 - `geodesic-interpolate` — required by `mixed_interpolate`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
   'matplotlib >= 3.8.4',
   'natsort >= 8.3.1',
   'numpy >= 1.24.3',
-  'pymatgen >= 2023.5.10',  
+  'pymatgen >= 2023.5.10',
+  'scipy >= 1.10.0',
 ]
 version = "1.1.0"
 authors = [


### PR DESCRIPTION
## Summary
- Adds `scipy >= 1.10.0` to `pyproject.toml` dependencies
- `mixed_interpolate.py` and `xyz2POSCAR.py` (PRs #15, #16) import `scipy.optimize.leastsq` for plane fitting, but scipy was not declared — causes `ImportError` on fresh installs
- Updates CLAUDE.md key dependencies table

## Test plan
- [ ] `pip install -e .` in a clean venv succeeds and includes scipy
- [ ] Existing tests still pass (no scipy-dependent tests yet, but no breakage expected)

Can be merged independently of #15 / #16 — scipy is a no-op dependency until those PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)