### PR TITLE
fix(getPOTCAR): rework path warnings, add ASE compat, add Fe/Cf

### DIFF
--- a/src/tools4vasp/bash_scripts/getPOTCAR.sh
+++ b/src/tools4vasp/bash_scripts/getPOTCAR.sh
@@ -5,10 +5,27 @@
 if [ -z "${VASP_PP_PATH:-}" ]; then
     printf "\n\e[38;5;1m* Error: VASP_PP_PATH environment variable is not set.\e[0m\n"
     printf "  Set it to the directory containing your VASP pseudopotentials, e.g.:\n"
-    printf "  export VASP_PP_PATH=/path/to/potpaw_PBE\n\n"
+    printf "  export VASP_PP_PATH=/path/to/potpaw_PBE.64\n"
+    printf "  (ASE-style parent directory paths are also accepted.)\n\n"
     exit 1
 fi
 POTDIR="${VASP_PP_PATH%/}/"
+
+# ASE compatibility: if VASP_PP_PATH points to a parent directory containing
+# potpaw_PBE* subdirectories (ASE convention), auto-resolve to the best match.
+if [ ! -d "${POTDIR}H" ] && [ ! -d "${POTDIR}Li" ]; then
+    # No element directories found directly — try ASE-style parent layout
+    best_match=""
+    for candidate in "${POTDIR}"potpaw_PBE*; do
+        if [ -d "$candidate" ]; then
+            best_match="$candidate"
+        fi
+    done
+    if [ -n "$best_match" ]; then
+        POTDIR="${best_match%/}/"
+        printf "\e[38;5;3m* Info:\e[0m Auto-resolved VASP_PP_PATH to %s\n" "$POTDIR"
+    fi
+fi
 
 # Some general variables 
 myPWD=$(pwd)
@@ -34,18 +51,19 @@ function usage
     echo "  -g          :  If you want the _GW extension of the POTCAR (opt. for unoccupied states)"
     echo "  -G          :  If you want the _sv_GW extension of the POTCAR (see _sv & _GW)"
     echo " "
-    echo "* IMPORTANT   :  It uses the following extensions as the recommended default potentials (-r):"
-    echo "  None        :  H, He, Be, B, C, N, O, F, Ne, Mg, Al, Si, P, S, Cl, Ar, Co,"
+    echo "* IMPORTANT   :  It uses the following extensions as the recommended default potentials for the PBE functional (-r):"
+    echo "  None        :  H, He, Be, B, C, N, O, F, Ne, Mg, Al, Si, P, S, Cl, Ar, Fe, Co,"
     echo "                 Ni, Cu, Zn, As, Se, Br, Kr, Pd, Ag, Cd, Sb, Te, I, Xe, La, Ce,"
-    echo "                 Re, Os, Ir, Pt, Au, Hg, At, Rn, Ac, Th, Pa, U, Np, Pu, Am, Cm"
+    echo "                 Re, Os, Ir, Pt, Au, Hg, At, Rn, Ac, Th, Pa, U, Np, Pu, Am, Cm, (Cf)"
     echo "  sv          :  Li, K, Ca, Sc, Ti, V, Rb, Sr, Y, Zr, Nb, Mo, Cs, Ba, W, Fr, Ra"
     echo "  pv          :  Na, Cr, Mn, Tc, Ru, Rh, Hf, Ta"
     echo "  d           :  Ga, Ge, In, Sn, Tl, Pb, Bi, Po"
     echo "  2           :  Eu, Yb"
     echo "  3           :  Pr, Nd, Pm, Sm, Gd, Tb, Dy, Ho, Er, Tm, Lu"
     echo " "
-    echo "* NOTE        :  Requires the VASP_PP_PATH environment variable to point to the pseudopotential directory."
-    echo "                 You must run this from the folder that contains the POSCAR."
+    echo "* NOTE        :  Requires the VASP_PP_PATH environment variable to point to the pseudopotential directory"
+    echo "                 (e.g. /path/to/potpaw_PBE.64). ASE-style parent paths (e.g. /path/to/potentials/) are also"
+    echo "                 accepted and auto-resolved. You must run this from the folder that contains the POSCAR."
     echo " "
     echo "---------------  Enjoy. Have a good day.  ---------------"
     echo " "
@@ -102,14 +120,25 @@ fi
 
 # Definition of recommended default options
 declare -A element_group=(
-    [H]="" [He]="" [Be]="" [B]="" [C]="" [N]="" [O]="" [F]="" [Ne]="" [Mg]="" [Al]="" [Si]="" [P]="" [S]="" [Cl]="" [Ar]="" [Co]="" [Ni]="" [Cu]="" [Zn]="" [As]="" [Se]="" [Br]="" [Kr]=""
-    [Pd]="" [Ag]="" [Cd]="" [Sb]="" [Te]="" [I]="" [Xe]="" [La]="" [Ce]="" [Re]="" [Os]="" [Ir]="" [Pt]="" [Au]="" [Hg]="" [At]="" [Rn]="" [Ac]="" [Th]="" [Pa]="" [U]="" [Np]="" [Pu]="" [Am]="" [Cm]=""
+    [H]="" [He]="" [Be]="" [B]="" [C]="" [N]="" [O]="" [F]="" [Ne]="" [Mg]="" [Al]="" [Si]="" [P]="" [S]="" [Cl]="" [Ar]="" [Fe]="" [Co]="" [Ni]="" [Cu]="" [Zn]="" [As]="" [Se]="" [Br]="" [Kr]=""
+    [Pd]="" [Ag]="" [Cd]="" [Sb]="" [Te]="" [I]="" [Xe]="" [La]="" [Ce]="" [Re]="" [Os]="" [Ir]="" [Pt]="" [Au]="" [Hg]="" [At]="" [Rn]="" [Ac]="" [Th]="" [Pa]="" [U]="" [Np]="" [Pu]="" [Am]="" [Cm]="" [Cf]=""
     [Li]="_sv" [K]="_sv" [Ca]="_sv" [Sc]="_sv" [Ti]="_sv" [V]="_sv" [Rb]="_sv" [Sr]="_sv" [Y]="_sv" [Zr]="_sv" [Nb]="_sv" [Mo]="_sv" [Cs]="_sv" [Ba]="_sv" [W]="_sv" [Fr]="_sv" [Ra]="_sv"
     [Na]="_pv" [Cr]="_pv" [Mn]="_pv" [Tc]="_pv" [Ru]="_pv" [Rh]="_pv" [Hf]="_pv" [Ta]="_pv"
     [Ga]="_d" [Ge]="_d" [In]="_d" [Sn]="_d" [Tl]="_d" [Pb]="_d" [Bi]="_d" [Po]="_d"
     [Eu]="_2" [Yb]="_2"
     [Pr]="_3" [Nd]="_3" [Pm]="_3" [Sm]="_3" [Gd]="_3" [Tb]="_3" [Dy]="_3" [Ho]="_3" [Er]="_3" [Tm]="_3" [Lu]="_3"
 )
+
+# Sanity checks for -r mode: recommended defaults are PBE-specific
+if [ "$decision" == "1" ]; then
+    potdir_lower="${POTDIR,,}"
+    if [[ "$potdir_lower" != *"pbe"* ]]; then
+        printf "\e[38;5;9;4m* Warning:\e[0m The recommended defaults (-r) are for the PBE functional, but VASP_PP_PATH does not appear to contain PBE potentials.\n"
+    fi
+    if [[ "$POTDIR" != *".64"* ]]; then
+        printf "\e[38;5;9;4m* Warning:\e[0m The recommended defaults (-r) are based on the .64 POTCAR dataset. Your path does not indicate this version.\n"
+    fi
+fi
 
 # Execution of creating the POTCAR
 if [ -f POSCAR ]; then # Check if POSCAR exists


### PR DESCRIPTION
## Summary

Resolves all issues raised in PR #19 discussion:

- **Element additions** (from #19): Add missing Fe and Cf to recommended defaults and `element_group` array
- **PBE clarification** (from #19): Help text now explicitly states recommendations are for PBE functional
- **Path warnings reworked** (review feedback): Scoped to `-r` mode only, case-insensitive PBE check, improved wording that explains *why* the warning fires instead of making incorrect claims about the POTCARs themselves
- **ASE-compatible `VASP_PP_PATH`** (Jakob's comment): Auto-detects whether `VASP_PP_PATH` points to a parent directory (ASE convention, e.g. `/path/to/potentials/`) vs the specific pseudopotential directory (e.g. `/path/to/potentials/potpaw_PBE.64/`). If the parent layout is detected, auto-resolves to the best `potpaw_PBE*` match with an info message

### Design decisions

- **Warnings scoped to `-r`**: This is the compromise between the review (remove or scope them) and Jakob's defense (they're useful sanity checks). Since the recommendations are PBE-specific, the warnings only make sense in `-r` mode.
- **ASE auto-detection heuristic**: Checks whether `H/` or `Li/` exist as direct subdirectories. If not, looks for `potpaw_PBE*` child directories. This avoids breaking existing setups while transparently supporting ASE-style paths.
- **No version bump**: This is a bugfix/improvement to an existing script, intended to supersede #19.

## Relation to PR #19

This PR implements the same element additions and help text improvements from #19, plus addresses all review feedback and the `VASP_PP_PATH` interoperability issue Jakob raised. If merged, #19 can be closed.

## Test plan

- [ ] ShellCheck passes (verified locally, will run in CI)
- [ ] Test with `VASP_PP_PATH=/path/to/potpaw_PBE.64/` (traditional) — should work as before
- [ ] Test with `VASP_PP_PATH=/path/to/potentials/` (ASE-style) — should auto-resolve with info message
- [ ] Test `-r` with non-PBE path — should show PBE warning
- [ ] Test `-n` with non-PBE path — should NOT show PBE warning
- [ ] Verify Fe and Cf work with `-r` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)