### PR TITLE
ci: chain release.yml from tag-on-merge via workflow_dispatch

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write  # needed to dispatch release.yml after tagging
 
 jobs:
   tag:
@@ -44,3 +45,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.version }}"
+
+      # GitHub suppresses on-push-tag triggers when the push is authenticated
+      # with GITHUB_TOKEN (recursion guard). workflow_dispatch is exempt, so
+      # we explicitly invoke release.yml against the new tag.
+      - name: Dispatch release workflow
+        if: steps.tag_exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml --ref "${{ steps.version.outputs.version }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,11 +99,17 @@ Key points:
   It does **not** trigger on feature-branch pushes to avoid duplicate runs.
 - Release workflow (`release.yml`) triggers on `v*` tags and publishes to PyPI.
 - Auto-tag workflow (`tag-on-merge.yml`) triggers on **push → main**: reads
-  `version` from `pyproject.toml`, creates tag `v<version>` if it doesn't exist,
-  which in turn triggers `release.yml`. **Merging a PR automatically produces a
-  release** — bump the version in `pyproject.toml` (and `CITATION.cff`) before
-  merging whenever a release is intended. If the tag already exists, no release
-  is created (safe for hotfixes merged without a version bump).
+  `version` from `pyproject.toml`, creates tag `v<version>` if it doesn't
+  exist, then explicitly dispatches `release.yml` against that tag via
+  `gh workflow run`. **Merging a PR automatically produces a release** — bump
+  the version in `pyproject.toml` (and `CITATION.cff`) before merging whenever
+  a release is intended. If the tag already exists, the dispatch step is
+  skipped (safe for hotfixes merged without a version bump).
+  - **Why the explicit dispatch:** GitHub suppresses on-push-tag triggers when
+    the push is authenticated with `GITHUB_TOKEN` (recursion guard), so
+    `release.yml`'s `on: push: tags: ["v*"]` does *not* fire from tags
+    created by this workflow. `workflow_dispatch` is the documented exception
+    to that rule. See the comment in `tag-on-merge.yml`.
 - TestPyPI publish (`pypi-publish.yml`) is manual (`workflow_dispatch` only).
 
 ### Releasing a new version


### PR DESCRIPTION
## Summary

`tag-on-merge.yml` has **never** successfully triggered `release.yml` since it was introduced. Both `v1.2.0` (merged 2026-04-17) and `v1.3.0` (merged 2026-05-12) tags were created on schedule, but no PyPI release ever followed automatically. The `v1.3.0` PyPI publish was unblocked manually with:

```bash
gh workflow run release.yml --ref v1.3.0
```

## Root cause

GitHub's recursion guard: when a workflow uses the default `GITHUB_TOKEN` (which `actions/checkout@v4` configures by default) to push something, the resulting event does **not** trigger further workflows. From the [docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run

So `release.yml`'s `on: push: tags: ["v*"]` trigger never fires for tags pushed by `tag-on-merge.yml`. Evidence:

```
$ gh run list --workflow=release.yml
v1.1.0  push       2026-03-12  success     ← last auto release
v1.0.1  push       2025-05-27  failure
v1.0.0  push       2025-05-27  failure
...
```
No entries for `v1.2.0` or `v1.3.0`.

## Fix

After pushing the new tag, explicitly invoke `release.yml` via `gh workflow run`. `workflow_dispatch` is the carve-out from the recursion guard, so this works without needing a PAT or GitHub App token. Adds `actions: write` to the workflow's permissions (required to dispatch).

Also corrects [CLAUDE.md](CLAUDE.md), which described the chain as already automatic.

## Test plan

- [ ] Merge this PR. The merge itself does not change `pyproject.toml`'s version, so `tag-on-merge.yml` should hit the `if: steps.tag_exists.outputs.exists == 'false'` guard as `false` (v1.3.0 already exists), skip both the tag-push and the new dispatch step, and exit cleanly — confirming the no-op path still works.
- [ ] On the next PR that bumps `version`, confirm the merge triggers `tag-on-merge.yml` → which pushes a new tag → which dispatches `release.yml` → which builds and publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)