### PR TITLE
vaspcheck/plotNEB: remove shell injection; fix electronic entropy check (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 - **`vaspcheck`** — The electronic-entropy check no longer shells out to `tail | grep` with an unquoted path. Paths containing spaces or shell metacharacters now work, and the command-injection vector is removed; the OUTCAR is parsed in pure Python.
-- **`vaspcheck`** — The electronic-entropy check now uses the energies of the *final* electronic step: the whole OUTCAR is scanned (not just the last 200 lines, which crashed for large systems) and the last `TOTEN` / `energy without entropy` block wins instead of the first match in the window. Matching is anchored on the literal OUTCAR line formats via regex. (Issue #24)
+- **`vaspcheck`** — The electronic-entropy check now uses the energies of the *final* electronic step: the OUTCAR is read backwards from the end (instead of only the last 200 lines, which crashed for large systems) and the last `TOTEN` / `energy without entropy` block wins instead of the first match in the window. Matching is anchored on the literal OUTCAR line formats via regex, and even multi-GB OUTCARs only have their tail touched. (Issue #24)
 - **`plotNEB`** — Dispersion energies (`Edisp`) are now read from the image OUTCARs in pure Python instead of via `grep | tail` with `shell=True`, removing the runtime dependency on `grep`/`tail` and the unquoted-path hazard.
 
 ## [1.3.0] - 2026-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [1.3.1] - 2026-06-11
 
 ### Bug Fixes
 
 - **`vaspcheck`** — The electronic-entropy check no longer shells out to `tail | grep` with an unquoted path. Paths containing spaces or shell metacharacters now work, and the command-injection vector is removed; the OUTCAR is parsed in pure Python.
+- **`vaspcheck`** — The electronic-entropy check now uses the energies of the *final* electronic step: the whole OUTCAR is scanned (not just the last 200 lines, which crashed for large systems) and the last `TOTEN` / `energy without entropy` block wins instead of the first match in the window. Matching is anchored on the literal OUTCAR line formats via regex. (Issue #24)
 - **`plotNEB`** — Dispersion energies (`Edisp`) are now read from the image OUTCARs in pure Python instead of via `grep | tail` with `shell=True`, removing the runtime dependency on `grep`/`tail` and the unquoted-path hazard.
 
 ## [1.3.0] - 2026-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **`vaspcheck`** — The electronic-entropy check no longer shells out to `tail | grep` with an unquoted path. Paths containing spaces or shell metacharacters now work, and the command-injection vector is removed; the OUTCAR is parsed in pure Python.
+- **`plotNEB`** — Dispersion energies (`Edisp`) are now read from the image OUTCARs in pure Python instead of via `grep | tail` with `shell=True`, removing the runtime dependency on `grep`/`tail` and the unquoted-path hazard.
+
 ## [1.3.0] - 2026-05-12
 
 ### New Tools

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: "If you use this software, please cite it as below."
 title: "VASP-tools"
 abstract: "A collection of Python and Bash tools for pre- and post-processing VASP DFT calculations."
 type: software
-version: "1.3.0"
-date-released: "2026-05-12"
+version: "1.3.1"
+date-released: "2026-06-11"
 license: MIT
 repository-code: "https://github.com/Tonner-Zech-Group/VASP-tools"
 doi: 10.5281/zenodo.15525217

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ plotIRC --reactant_dir irc_r/ --product_dir irc_p/ \
 | `split_vasp_freq` | Split a VASP frequency calculation into partial jobs and recombine. | `split_vasp_freq split 20` |
 | `vasp2traj` | Convert VASP OUTCAR or XDATCAR to an ext-xyz trajectory. | `vasp2traj traj.xyz OUTCAR` |
 | `vaspcheck` | Assert proper occupations and SCF+GO convergence using ASE. | `vaspcheck ./run` |
+| `vaspcheck-outcar` | Check SCF and ionic convergence directly from OUTCAR / OUTCAR.gz (no vasprun.xml needed). | `vaspcheck-outcar ./run` |
 | `vaspGetEF` | Plot energy and max force across multiple GO restart jobs. When a POSCAR with selective dynamics is found, forces are computed over free (unfrozen) components only — per-component constraints (e.g. `T T F`) are handled correctly. | `vaspGetEF ./run` |
 | `viewMode` | Animated preview of a MODECAR in the ASE GUI. | `viewMode --scale 2` |
 | `visualize-magnetization` | Create a VMD visualisation state for the magnetisation density. | `visualize-magnetization` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   'pymatgen >= 2023.5.10',
   'scipy >= 1.10.0',
 ]
-version = "1.3.0"
+version = "1.3.1"
 authors = [
   { name="Patrick Melix", email="patrick.melix@uni-leipzig.de" },
 ]

--- a/src/tools4vasp/_fileutils.py
+++ b/src/tools4vasp/_fileutils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Shared file-handling helpers for tools4vasp
+#
+import os
+
+
+def iter_lines_reversed(f, chunk_size=64 * 1024):
+    """Yield the lines of a binary file from last to first.
+
+    Reads the file in chunks starting from the end, so only as much of
+    the file is touched as the consumer actually iterates over. Useful
+    for pulling the final entries out of huge OUTCAR files without
+    reading the whole file.
+
+    Input Parameters
+    ----------------
+    f : binary file object
+        Seekable file opened in binary mode
+
+    chunk_size : int
+        Number of bytes to read per backwards step, must be positive
+
+    Returns
+    -------
+    Generator of lines (bytes, without trailing newline), last line first.
+    """
+    if chunk_size <= 0:
+        raise ValueError(
+            "chunk_size must be positive, got {}".format(chunk_size))
+    f.seek(0, os.SEEK_END)
+    pos = f.tell()
+    carry = b""
+    while pos > 0:
+        size = min(chunk_size, pos)
+        pos -= size
+        f.seek(pos)
+        lines = (f.read(size) + carry).split(b"\n")
+        # the first element may be a partial line completed by the next
+        # (earlier) chunk — hold it back as carry
+        carry = lines[0]
+        for line in reversed(lines[1:]):
+            yield line
+    if carry:
+        yield carry

--- a/src/tools4vasp/plotNEB.py
+++ b/src/tools4vasp/plotNEB.py
@@ -11,6 +11,7 @@ import numpy as np
 from matplotlib.ticker import MaxNLocator
 from ase.units import create_units
 from matplotlib import pyplot as plt
+from tools4vasp._fileutils import iter_lines_reversed
 
 
 def plot(reactionCoord, reactionCoordImageAxis, energies, energySpline, forces, filename, lw=3, s=0, highlight=None, dispersion=None, unit="kJ/mol"):
@@ -130,11 +131,16 @@ def run(filename='NEB.png', presentation=False,
             outcar = os.path.join(path,'OUTCAR')
             assert os.path.isfile(outcar), "Could not find file {}".format(outcar)
             dispE = None
-            with open(outcar) as f:
-                for line in f:
-                    if 'Edisp (eV)' in line:
-                        dispE = float(line.split()[-1])
-            assert dispE is not None, "No 'Edisp (eV)' entry found in {}".format(outcar)
+            # the last Edisp entry is wanted — read the file backwards so
+            # huge OUTCARs only have their tail touched
+            with open(outcar, 'rb') as f:
+                for raw_line in iter_lines_reversed(f):
+                    if b'Edisp (eV)' in raw_line:
+                        dispE = float(raw_line.split()[-1])
+                        break
+            if dispE is None:
+                raise ValueError(
+                    "No 'Edisp (eV)' entry found in {}".format(outcar))
             dispersion.append(dispE)
         dispersion = np.array(dispersion)
         dispersion -= dispersion[0]

--- a/src/tools4vasp/plotNEB.py
+++ b/src/tools4vasp/plotNEB.py
@@ -5,10 +5,8 @@
 # 2022/01
 #
 # You can import the module and then call .main() or use it as a script
-# Needs grep and tail.
 import argparse
 import os
-import subprocess
 import numpy as np
 from matplotlib.ticker import MaxNLocator
 from ase.units import create_units
@@ -131,8 +129,12 @@ def run(filename='NEB.png', presentation=False,
             assert os.path.isdir(path), "Could not find dir {}".format(path)
             outcar = os.path.join(path,'OUTCAR')
             assert os.path.isfile(outcar), "Could not find file {}".format(outcar)
-            child = subprocess.Popen(["grep 'Edisp (eV)' {:} | tail -1".format(outcar)], stdout=subprocess.PIPE, shell=True)
-            dispE = float(child.communicate()[0].strip().split()[-1])
+            dispE = None
+            with open(outcar) as f:
+                for line in f:
+                    if 'Edisp (eV)' in line:
+                        dispE = float(line.split()[-1])
+            assert dispE is not None, "No 'Edisp (eV)' entry found in {}".format(outcar)
             dispersion.append(dispE)
         dispersion = np.array(dispersion)
         dispersion -= dispersion[0]

--- a/src/tools4vasp/vaspcheck.py
+++ b/src/tools4vasp/vaspcheck.py
@@ -96,10 +96,14 @@ def check_vasp_occupations(calc) -> Optional[str]:
 
 
 def _get_entropy_energies(outcar) -> tuple:
-    """Parse TOTEN and the energy without entropy from an OUTCAR file.
+    """Parse the final TOTEN and energy without entropy from an OUTCAR file.
 
-    Looks at the last 200 lines, takes the first "TOTEN" line and the
-    "energy without entropy" line that follows within four lines.
+    Scans the whole file and returns the energies of the *last* "TOTEN"
+    line that is followed by an "energy without entropy" line within four
+    lines, i.e. the final electronic step. Earlier implementations only
+    looked at the last 200 lines (crashing for large systems where the
+    block sits further from the end) and took the first match instead of
+    the final one (issue #24).
 
     Input Parameters
     ----------------
@@ -110,16 +114,26 @@ def _get_entropy_energies(outcar) -> tuple:
     -------
     Tuple of (TOTEN, energy without entropy) in eV.
     """
+    toten = e_wo_entropy = None
+    pending_toten = None
+    lines_since_toten = 0
     with open(outcar) as f:
-        lines = f.readlines()[-200:]
-    for i, line in enumerate(lines):
-        if "TOTEN" in line:
-            toten = float(line.split()[-2])
-            for next_line in lines[i + 1:i + 5]:
-                if "energy" in next_line and "entropy" in next_line:
-                    return toten, float(next_line.split()[3])
-            break
-    raise ValueError("Could not parse TOTEN/entropy from {}".format(outcar))
+        for line in f:
+            if "TOTEN" in line:
+                pending_toten = float(line.split()[-2])
+                lines_since_toten = 0
+            elif pending_toten is not None:
+                lines_since_toten += 1
+                if "energy" in line and "entropy" in line:
+                    toten = pending_toten
+                    e_wo_entropy = float(line.split()[3])
+                    pending_toten = None
+                elif lines_since_toten >= 4:
+                    pending_toten = None
+    if toten is None:
+        raise ValueError(
+            "Could not parse TOTEN/entropy from {}".format(outcar))
+    return toten, e_wo_entropy
 
 
 def check_vasp_electronic_entropy(path, calc, limit=0.001) -> Optional[str]:

--- a/src/tools4vasp/vaspcheck.py
+++ b/src/tools4vasp/vaspcheck.py
@@ -11,6 +11,7 @@ import os
 import re
 import numpy as np
 from typing import Optional
+from tools4vasp._fileutils import iter_lines_reversed
 
 # OUTCAR final-energy block, e.g.:
 #   free  energy   TOTEN  =       -68.41063650 eV
@@ -102,41 +103,6 @@ def check_vasp_occupations(calc) -> Optional[str]:
     return
 
 
-def _iter_lines_reversed(f, chunk_size=64 * 1024):
-    """Yield the lines of a binary file from last to first.
-
-    Reads the file in chunks starting from the end, so only as much of
-    the file is touched as the consumer actually iterates over.
-
-    Input Parameters
-    ----------------
-    f : binary file object
-        Seekable file opened in binary mode
-
-    chunk_size : int
-        Number of bytes to read per backwards step
-
-    Returns
-    -------
-    Generator of lines (bytes, without trailing newline), last line first.
-    """
-    f.seek(0, os.SEEK_END)
-    pos = f.tell()
-    carry = b""
-    while pos > 0:
-        size = min(chunk_size, pos)
-        pos -= size
-        f.seek(pos)
-        lines = (f.read(size) + carry).split(b"\n")
-        # the first element may be a partial line completed by the next
-        # (earlier) chunk — hold it back as carry
-        carry = lines[0]
-        for line in reversed(lines[1:]):
-            yield line
-    if carry:
-        yield carry
-
-
 def _get_entropy_energies(outcar, chunk_size=64 * 1024) -> tuple:
     """Parse the final TOTEN and energy without entropy from an OUTCAR file.
 
@@ -154,7 +120,7 @@ def _get_entropy_energies(outcar, chunk_size=64 * 1024) -> tuple:
         Path to the OUTCAR file
 
     chunk_size : int
-        Number of bytes per backwards read step
+        Number of bytes per backwards read step, must be positive
 
     Returns
     -------
@@ -163,7 +129,7 @@ def _get_entropy_energies(outcar, chunk_size=64 * 1024) -> tuple:
     e_wo_entropy = None
     lines_above_entropy = 0
     with open(outcar, "rb") as f:
-        for raw_line in _iter_lines_reversed(f, chunk_size=chunk_size):
+        for raw_line in iter_lines_reversed(f, chunk_size=chunk_size):
             line = raw_line.decode(errors="replace")
             if e_wo_entropy is None:
                 entropy_match = _E_WO_ENTROPY_RE.search(line)

--- a/src/tools4vasp/vaspcheck.py
+++ b/src/tools4vasp/vaspcheck.py
@@ -10,7 +10,6 @@ from ase import io
 import os
 import numpy as np
 from typing import Optional
-import subprocess
 
 def _get_elements_from_outcar(f: TextIOWrapper) -> list:
     """Get elements from OUTCAR file.
@@ -96,6 +95,33 @@ def check_vasp_occupations(calc) -> Optional[str]:
     return
 
 
+def _get_entropy_energies(outcar) -> tuple:
+    """Parse TOTEN and the energy without entropy from an OUTCAR file.
+
+    Looks at the last 200 lines, takes the first "TOTEN" line and the
+    "energy without entropy" line that follows within four lines.
+
+    Input Parameters
+    ----------------
+    outcar : str
+        Path to the OUTCAR file
+
+    Returns
+    -------
+    Tuple of (TOTEN, energy without entropy) in eV.
+    """
+    with open(outcar) as f:
+        lines = f.readlines()[-200:]
+    for i, line in enumerate(lines):
+        if "TOTEN" in line:
+            toten = float(line.split()[-2])
+            for next_line in lines[i + 1:i + 5]:
+                if "energy" in next_line and "entropy" in next_line:
+                    return toten, float(next_line.split()[3])
+            break
+    raise ValueError("Could not parse TOTEN/entropy from {}".format(outcar))
+
+
 def check_vasp_electronic_entropy(path, calc, limit=0.001) -> Optional[str]:
     """Check if the electronic entropy is larger than limit.
     
@@ -119,11 +145,7 @@ def check_vasp_electronic_entropy(path, calc, limit=0.001) -> Optional[str]:
     if ret:
         print("Integer occupation check returned: {:}".format(ret))
         outcar = os.path.join(path, "OUTCAR")
-        cmd = 'tail -n 200 {} | grep -A 4 "TOTEN"'.format(outcar)
-        res = subprocess.check_output([cmd], shell=True).decode('utf-8')
-        res = res.split('\n\n')
-        toten = float(res[0].split()[-2])
-        e_wo_entropy = float(res[1].split()[3])
+        toten, e_wo_entropy = _get_entropy_energies(outcar)
         entropy = toten - e_wo_entropy
         mol = io.read(os.path.join(path, 'CONTCAR'))
         entropy_per_atom = entropy / len(mol)

--- a/src/tools4vasp/vaspcheck.py
+++ b/src/tools4vasp/vaspcheck.py
@@ -102,47 +102,83 @@ def check_vasp_occupations(calc) -> Optional[str]:
     return
 
 
-def _get_entropy_energies(outcar) -> tuple:
+def _iter_lines_reversed(f, chunk_size=64 * 1024):
+    """Yield the lines of a binary file from last to first.
+
+    Reads the file in chunks starting from the end, so only as much of
+    the file is touched as the consumer actually iterates over.
+
+    Input Parameters
+    ----------------
+    f : binary file object
+        Seekable file opened in binary mode
+
+    chunk_size : int
+        Number of bytes to read per backwards step
+
+    Returns
+    -------
+    Generator of lines (bytes, without trailing newline), last line first.
+    """
+    f.seek(0, os.SEEK_END)
+    pos = f.tell()
+    carry = b""
+    while pos > 0:
+        size = min(chunk_size, pos)
+        pos -= size
+        f.seek(pos)
+        lines = (f.read(size) + carry).split(b"\n")
+        # the first element may be a partial line completed by the next
+        # (earlier) chunk — hold it back as carry
+        carry = lines[0]
+        for line in reversed(lines[1:]):
+            yield line
+    if carry:
+        yield carry
+
+
+def _get_entropy_energies(outcar, chunk_size=64 * 1024) -> tuple:
     """Parse the final TOTEN and energy without entropy from an OUTCAR file.
 
-    Scans the whole file and returns the energies of the *last*
-    "free energy TOTEN" line that is followed by an "energy without
-    entropy" line within four lines, i.e. the final electronic step.
-    Earlier implementations only looked at the last 200 lines (crashing
-    for large systems where the block sits further from the end) and took
-    the first match instead of the final one (issue #24).
+    Returns the energies of the *last* "free energy TOTEN" line that is
+    followed by an "energy without entropy" line within four lines, i.e.
+    the final electronic step. The file is read backwards from the end,
+    so even multi-GB OUTCARs only have their tail touched. Earlier
+    implementations only looked at the last 200 lines (crashing for large
+    systems where the block sits further from the end) and took the first
+    match instead of the final one (issue #24).
 
     Input Parameters
     ----------------
     outcar : str
         Path to the OUTCAR file
 
+    chunk_size : int
+        Number of bytes per backwards read step
+
     Returns
     -------
     Tuple of (TOTEN, energy without entropy) in eV.
     """
-    toten = e_wo_entropy = None
-    pending_toten = None
-    lines_since_toten = 0
-    with open(outcar) as f:
-        for line in f:
-            toten_match = _TOTEN_RE.search(line)
-            if toten_match:
-                pending_toten = float(toten_match.group(1))
-                lines_since_toten = 0
-            elif pending_toten is not None:
-                lines_since_toten += 1
+    e_wo_entropy = None
+    lines_above_entropy = 0
+    with open(outcar, "rb") as f:
+        for raw_line in _iter_lines_reversed(f, chunk_size=chunk_size):
+            line = raw_line.decode(errors="replace")
+            if e_wo_entropy is None:
                 entropy_match = _E_WO_ENTROPY_RE.search(line)
                 if entropy_match:
-                    toten = pending_toten
                     e_wo_entropy = float(entropy_match.group(1))
-                    pending_toten = None
-                elif lines_since_toten >= 4:
-                    pending_toten = None
-    if toten is None:
-        raise ValueError(
-            "Could not parse TOTEN/entropy from {}".format(outcar))
-    return toten, e_wo_entropy
+                    lines_above_entropy = 0
+            else:
+                lines_above_entropy += 1
+                toten_match = _TOTEN_RE.search(line)
+                if toten_match:
+                    return float(toten_match.group(1)), e_wo_entropy
+                if lines_above_entropy >= 4:
+                    # unpaired entropy line — keep searching earlier ones
+                    e_wo_entropy = None
+    raise ValueError("Could not parse TOTEN/entropy from {}".format(outcar))
 
 
 def check_vasp_electronic_entropy(path, calc, limit=0.001) -> Optional[str]:

--- a/src/tools4vasp/vaspcheck.py
+++ b/src/tools4vasp/vaspcheck.py
@@ -8,8 +8,15 @@ from io import TextIOWrapper
 from ase.calculators.vasp.vasp import Vasp
 from ase import io
 import os
+import re
 import numpy as np
 from typing import Optional
+
+# OUTCAR final-energy block, e.g.:
+#   free  energy   TOTEN  =       -68.41063650 eV
+#   energy  without entropy=      -68.40903650  energy(sigma->0) = ...
+_TOTEN_RE = re.compile(r"free\s+energy\s+TOTEN\s*=\s*(-?\d+\.\d+)")
+_E_WO_ENTROPY_RE = re.compile(r"energy\s+without\s+entropy\s*=\s*(-?\d+\.\d+)")
 
 def _get_elements_from_outcar(f: TextIOWrapper) -> list:
     """Get elements from OUTCAR file.
@@ -98,12 +105,12 @@ def check_vasp_occupations(calc) -> Optional[str]:
 def _get_entropy_energies(outcar) -> tuple:
     """Parse the final TOTEN and energy without entropy from an OUTCAR file.
 
-    Scans the whole file and returns the energies of the *last* "TOTEN"
-    line that is followed by an "energy without entropy" line within four
-    lines, i.e. the final electronic step. Earlier implementations only
-    looked at the last 200 lines (crashing for large systems where the
-    block sits further from the end) and took the first match instead of
-    the final one (issue #24).
+    Scans the whole file and returns the energies of the *last*
+    "free energy TOTEN" line that is followed by an "energy without
+    entropy" line within four lines, i.e. the final electronic step.
+    Earlier implementations only looked at the last 200 lines (crashing
+    for large systems where the block sits further from the end) and took
+    the first match instead of the final one (issue #24).
 
     Input Parameters
     ----------------
@@ -119,14 +126,16 @@ def _get_entropy_energies(outcar) -> tuple:
     lines_since_toten = 0
     with open(outcar) as f:
         for line in f:
-            if "TOTEN" in line:
-                pending_toten = float(line.split()[-2])
+            toten_match = _TOTEN_RE.search(line)
+            if toten_match:
+                pending_toten = float(toten_match.group(1))
                 lines_since_toten = 0
             elif pending_toten is not None:
                 lines_since_toten += 1
-                if "energy" in line and "entropy" in line:
+                entropy_match = _E_WO_ENTROPY_RE.search(line)
+                if entropy_match:
                     toten = pending_toten
-                    e_wo_entropy = float(line.split()[3])
+                    e_wo_entropy = float(entropy_match.group(1))
                     pending_toten = None
                 elif lines_since_toten >= 4:
                     pending_toten = None

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -331,6 +331,65 @@ def test_get_entropy_energies_path_with_spaces_and_metachars(tmp_path):
     assert not (evil_dir / "pwned").exists()
 
 
+# ---------------------------------------------------------------------------
+# Issue #24 — vaspcheck: entropy check must use the FINAL TOTEN block and
+# must not depend on the block being within the last 200 lines
+# ---------------------------------------------------------------------------
+
+OUTCAR_TOTEN_BLOCK_FINAL = """\
+--------------------------------------- Iteration      2(  13)  ----------
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =       -70.12345678 eV
+
+  energy  without entropy=      -70.12245678  energy(sigma->0) =      -70.12295678
+"""
+
+
+def test_get_entropy_energies_takes_last_toten_block(tmp_path):
+    """With multiple TOTEN entries the final one must be used (issue #24)."""
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    outcar.write_text(OUTCAR_TOTEN_BLOCK + "\n" + OUTCAR_TOTEN_BLOCK_FINAL)
+
+    toten, e_wo_entropy = _get_entropy_energies(str(outcar))
+    assert toten == pytest.approx(-70.12345678)
+    assert e_wo_entropy == pytest.approx(-70.12245678)
+
+
+def test_get_entropy_energies_block_beyond_last_200_lines(tmp_path):
+    """TOTEN deeper than 200 lines from the end must still parse (issue #24).
+
+    Large systems print long property tables after the final energies, so
+    the old `tail -n 200`-style window crashed on them.
+    """
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    trailing = "\n".join("  some other OUTCAR output line {}".format(i)
+                         for i in range(300))
+    outcar.write_text(OUTCAR_TOTEN_BLOCK + "\n" + trailing + "\n")
+
+    toten, e_wo_entropy = _get_entropy_energies(str(outcar))
+    assert toten == pytest.approx(-68.41063650)
+    assert e_wo_entropy == pytest.approx(-68.40903650)
+
+
+def test_get_entropy_energies_unpaired_toten_raises(tmp_path):
+    """A TOTEN line with no entropy line within four lines must not match."""
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    outcar.write_text(
+        "  free  energy   TOTEN  =       -68.41063650 eV\n"
+        + "filler\n" * 10)
+
+    with pytest.raises(ValueError):
+        _get_entropy_energies(str(outcar))
+
+
 def test_get_entropy_energies_missing_block_raises(tmp_path):
     """A clear ValueError must be raised when no TOTEN block is found."""
     from tools4vasp.vaspcheck import _get_entropy_energies

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -430,9 +430,30 @@ def test_plotNEB_dispersion_read_without_shell(tmp_path, monkeypatch):
 
 
 def test_plotNEB_module_does_not_use_subprocess():
-    """plotNEB must not shell out at all (grep/tail dependency removed)."""
+    """plotNEB must not shell out at all (grep/tail dependency removed).
+
+    Inspects the AST rather than the raw source so that mere mentions of
+    "subprocess" in comments/docstrings (or other harmless refactors)
+    don't trip the test — only real imports or shell=... call keywords do.
+    """
+    import ast
     import tools4vasp.plotNEB as mod
 
-    src = inspect.getsource(mod)
-    assert "subprocess" not in src
-    assert "shell=True" not in src
+    tree = ast.parse(inspect.getsource(mod))
+    imports = [
+        name.name
+        for node in ast.walk(tree) if isinstance(node, ast.Import)
+        for name in node.names
+    ] + [
+        node.module
+        for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    ]
+    assert not any(name == "subprocess" or name.startswith("subprocess.")
+                   for name in imports if name)
+
+    shell_keywords = [
+        kw
+        for node in ast.walk(tree) if isinstance(node, ast.Call)
+        for kw in node.keywords if kw.arg == "shell"
+    ]
+    assert not shell_keywords

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -390,6 +390,63 @@ def test_get_entropy_energies_unpaired_toten_raises(tmp_path):
         _get_entropy_energies(str(outcar))
 
 
+def test_get_entropy_energies_across_chunk_boundaries(tmp_path):
+    """Backwards chunked reading must reassemble lines split mid-chunk.
+
+    A tiny chunk_size forces every line of the TOTEN block to straddle
+    chunk boundaries; the parser must still find the final block.
+    """
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    filler = "\n".join("  some other OUTCAR output line {}".format(i)
+                       for i in range(50))
+    outcar.write_text(OUTCAR_TOTEN_BLOCK + "\n"
+                      + OUTCAR_TOTEN_BLOCK_FINAL + "\n" + filler + "\n")
+
+    for chunk_size in (1, 7, 64):
+        toten, e_wo_entropy = _get_entropy_energies(
+            str(outcar), chunk_size=chunk_size)
+        assert toten == pytest.approx(-70.12345678)
+        assert e_wo_entropy == pytest.approx(-70.12245678)
+
+
+def test_get_entropy_energies_reads_only_file_tail(tmp_path):
+    """Only the tail of a huge OUTCAR may be read, not the whole file.
+
+    The final TOTEN block sits at the end of a file with a large body;
+    counting the bytes actually read must show the body was never touched.
+    """
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    body = "  bulk OUTCAR line\n" * 200_000  # ~3.8 MB
+    outcar.write_text(body + OUTCAR_TOTEN_BLOCK)
+
+    bytes_read = 0
+    real_open = open
+
+    def counting_open(*open_args, **open_kwargs):
+        handle = real_open(*open_args, **open_kwargs)
+        real_read = handle.read
+
+        def counting_read(*read_args, **read_kwargs):
+            nonlocal bytes_read
+            data = real_read(*read_args, **read_kwargs)
+            bytes_read += len(data)
+            return data
+
+        handle.read = counting_read
+        return handle
+
+    with patch("builtins.open", counting_open):
+        toten, e_wo_entropy = _get_entropy_energies(str(outcar))
+
+    assert toten == pytest.approx(-68.41063650)
+    assert e_wo_entropy == pytest.approx(-68.40903650)
+    assert bytes_read <= 128 * 1024  # a couple of chunks, not ~3.8 MB
+
+
 def test_get_entropy_energies_missing_block_raises(tmp_path):
     """A clear ValueError must be raised when no TOTEN block is found."""
     from tools4vasp.vaspcheck import _get_entropy_energies

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -283,3 +283,97 @@ def test_get_all_xmls_parameter_name():
         # Should not raise TypeError for unexpected keyword argument
         result = get_all_xmls(d, verbose=False)
     assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Bug 11 — vaspcheck / plotNEB: shell=True command injection via file paths
+# ---------------------------------------------------------------------------
+
+OUTCAR_TOTEN_BLOCK = """\
+--------------------------------------- Iteration      2(  12)  ----------
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =       -68.41063650 eV
+
+  energy  without entropy=      -68.40903650  energy(sigma->0) =      -68.41010317
+"""
+
+
+def test_get_entropy_energies_parses_outcar(tmp_path):
+    """_get_entropy_energies must parse TOTEN and entropy-free energy."""
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    outcar.write_text(OUTCAR_TOTEN_BLOCK)
+
+    toten, e_wo_entropy = _get_entropy_energies(str(outcar))
+    assert toten == pytest.approx(-68.41063650)
+    assert e_wo_entropy == pytest.approx(-68.40903650)
+
+
+def test_get_entropy_energies_path_with_spaces_and_metachars(tmp_path):
+    """Paths with spaces/shell metacharacters must work (no shell involved).
+
+    The old implementation interpolated the path into a `tail | grep`
+    shell pipeline, which broke on spaces and allowed command injection.
+    """
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    evil_dir = tmp_path / "my calc; $(touch pwned)"
+    evil_dir.mkdir()
+    outcar = evil_dir / "OUTCAR"
+    outcar.write_text(OUTCAR_TOTEN_BLOCK)
+
+    toten, e_wo_entropy = _get_entropy_energies(str(outcar))
+    assert toten == pytest.approx(-68.41063650)
+    assert not (tmp_path / "pwned").exists()
+    assert not (evil_dir / "pwned").exists()
+
+
+def test_get_entropy_energies_missing_block_raises(tmp_path):
+    """A clear ValueError must be raised when no TOTEN block is found."""
+    from tools4vasp.vaspcheck import _get_entropy_energies
+
+    outcar = tmp_path / "OUTCAR"
+    outcar.write_text("nothing useful here\n")
+
+    with pytest.raises(ValueError):
+        _get_entropy_energies(str(outcar))
+
+
+def test_plotNEB_dispersion_read_without_shell(tmp_path, monkeypatch):
+    """run(plot_dispersion=True) must read Edisp from OUTCARs without a shell."""
+    from tools4vasp import plotNEB
+
+    monkeypatch.chdir(tmp_path)
+    n_img = 3
+    # minimal spline.dat / neb.dat: columns (idx, x, E, F)
+    spline_lines = []
+    for i in range(10):
+        x = i / 9.0
+        spline_lines.append("{} {} {} {}".format(i, x, 0.0, 0.0))
+    (tmp_path / "spline.dat").write_text("\n".join(spline_lines) + "\n")
+    neb_lines = []
+    for i in range(n_img):
+        neb_lines.append("{} {} {} {}".format(i, i / 2.0, 0.1 * i, 0.0))
+    (tmp_path / "neb.dat").write_text("\n".join(neb_lines) + "\n")
+    for i in range(n_img):
+        d = tmp_path / "{:02d}".format(i)
+        d.mkdir()
+        (d / "OUTCAR").write_text(
+            "  Edisp (eV) =   -0.10000\n"
+            "  Edisp (eV) =   -{:.5f}\n".format(0.2 + 0.1 * i)
+        )
+
+    plotNEB.run(filename=str(tmp_path / "NEB.png"), plot_dispersion=True)
+    assert (tmp_path / "NEB.png").exists()
+
+
+def test_plotNEB_module_does_not_use_subprocess():
+    """plotNEB must not shell out at all (grep/tail dependency removed)."""
+    import tools4vasp.plotNEB as mod
+
+    src = inspect.getsource(mod)
+    assert "subprocess" not in src
+    assert "shell=True" not in src

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -423,28 +423,58 @@ def test_get_entropy_energies_reads_only_file_tail(tmp_path):
     body = "  bulk OUTCAR line\n" * 200_000  # ~3.8 MB
     outcar.write_text(body + OUTCAR_TOTEN_BLOCK)
 
-    bytes_read = 0
+    bytes_read = [0]
     real_open = open
 
-    def counting_open(*open_args, **open_kwargs):
-        handle = real_open(*open_args, **open_kwargs)
-        real_read = handle.read
+    class CountingFileProxy:
+        """Delegating wrapper counting bytes returned by read().
 
-        def counting_read(*read_args, **read_kwargs):
-            nonlocal bytes_read
-            data = real_read(*read_args, **read_kwargs)
-            bytes_read += len(data)
+        A proxy is used instead of assigning to handle.read because
+        method attributes of C-implemented file objects may be read-only.
+        """
+
+        def __init__(self, handle):
+            self._handle = handle
+
+        def read(self, *read_args, **read_kwargs):
+            data = self._handle.read(*read_args, **read_kwargs)
+            bytes_read[0] += len(data)
             return data
 
-        handle.read = counting_read
-        return handle
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return self._handle.__exit__(*exc_info)
+
+    def counting_open(*open_args, **open_kwargs):
+        return CountingFileProxy(real_open(*open_args, **open_kwargs))
 
     with patch("builtins.open", counting_open):
         toten, e_wo_entropy = _get_entropy_energies(str(outcar))
 
     assert toten == pytest.approx(-68.41063650)
     assert e_wo_entropy == pytest.approx(-68.40903650)
-    assert bytes_read <= 128 * 1024  # a couple of chunks, not ~3.8 MB
+    assert bytes_read[0] <= 128 * 1024  # a couple of chunks, not ~3.8 MB
+
+
+def test_iter_lines_reversed_rejects_nonpositive_chunk_size(tmp_path):
+    """chunk_size <= 0 must raise instead of looping forever."""
+    from tools4vasp.vaspcheck import _get_entropy_energies
+    from tools4vasp._fileutils import iter_lines_reversed
+
+    outcar = tmp_path / "OUTCAR"
+    outcar.write_text(OUTCAR_TOTEN_BLOCK)
+
+    for bad_chunk_size in (0, -1):
+        with pytest.raises(ValueError, match="chunk_size"):
+            _get_entropy_energies(str(outcar), chunk_size=bad_chunk_size)
+        with open(outcar, "rb") as f:
+            with pytest.raises(ValueError, match="chunk_size"):
+                list(iter_lines_reversed(f, chunk_size=bad_chunk_size))
 
 
 def test_get_entropy_energies_missing_block_raises(tmp_path):


### PR DESCRIPTION
## Summary

This branch bundles two fixes to `vaspcheck` (plus the same shell-injection cleanup in `plotNEB`) and bumps the version to 1.3.1 so merging triggers a patch release.

### 1. Remove `shell=True` command injection (74726b1)
`check_vasp_electronic_entropy` interpolated the OUTCAR path into a `tail -n 200 | grep -A 4 "TOTEN"` shell pipeline. Paths containing spaces or shell metacharacters broke the command or executed arbitrary code. The pipeline is replaced by a pure-Python parser (`_get_entropy_energies`); `plotNEB` received the same treatment.

### 2. Fix the electronic entropy check — closes #24 (e1e54a4, b9aedd3, 5ba041c)
As reported in #24, the parser had two bugs:

- **Crash for large systems**: only the last 200 lines of OUTCAR were inspected, so when long property tables follow the final energies, no TOTEN line was found.
- **Wrong block selected**: with multiple TOTEN entries in the window (e.g. small molecules), the *first* match was used instead of the final electronic step, so the check tested the wrong entropy.

`_get_entropy_energies` now reads the OUTCAR **backwards** in chunks from the end of the file and returns at the first complete `energy without entropy` / `TOTEN` pair found — by construction the final electronic step. Multi-GB OUTCARs from long MD runs only have their tail (typically one 64 KB chunk) touched. Matching is anchored on the literal OUTCAR line formats via regex (Copilot review), not substring checks plus positional `split()` indices.

### 3. Release: version 1.3.1 (fef2b0b)
Security + correctness fixes warrant a patch release. `pyproject.toml` and `CITATION.cff` bumped, `CHANGELOG.md` updated; merging auto-tags `v1.3.1` and publishes via the release workflow.

## Tests

- Regression tests: last-TOTEN-wins, TOTEN block buried >200 lines from the end, unpaired TOTEN raises `ValueError`, chunk-boundary reassembly down to `chunk_size=1`, and a bytes-read counter proving a ~3.8 MB synthetic OUTCAR body is never read.
- Full suite: **214 passed**; `ruff check` clean.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)